### PR TITLE
Example dbt Python model containing descriptive statistics

### DIFF
--- a/models/descriptive_statistics.py
+++ b/models/descriptive_statistics.py
@@ -1,0 +1,20 @@
+import pandas as pd
+
+
+def model(dbt, _):
+    dbt.config(
+        materialized="table",
+    )
+    relation = dbt.ref("survey_results")
+
+    # Convert the relation to a Pandas DataFrame
+    pdf = relation.to_df()
+
+    # Generate descriptive statistics of each question of the survey results
+    df = pdf.describe(include="all") #.transpose()
+
+    # Include the statistic name in the tabular output
+    df.reset_index(inplace=True)
+    df = df.rename(columns={"index": "statistic"})
+
+    return df

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ dbt-duckdb>=1.3.1
 
 # dbt Core 1.3
 dbt-core>=1.3.0
+
+# Pandas for dbt Python models
+pandas


### PR DESCRIPTION
Resolves #1

### Implementation details
Chose [pandas.DataFrame.describe](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.describe.html) as a nice way to quickly "summarize the central tendency, dispersion and shape of a dataset’s distribution" (excluding NaN values).

By default, the name of the statistic (`count`, `unique`, `mean`, `25%`, etc) is the row index, so I needed to [convert it to a column](https://datatofish.com/index-to-column-pandas-dataframe/) in order for it to be materialized in the tabular output.

### Example

Run the dbt Python model that uses `df.describe()`:
```shell
dbt run -s descriptive_statistics
```

Launch a DuckDB command-line interface (CLI):
```shell
duckcli ae_survey.duckdb
```

Run a query at the prompt and exit:
```sql
select statistic, "Does your organization use dbt Core or dbt Cloud today?" from descriptive_statistics;
exit;
```